### PR TITLE
apfsprogs: add LDFLAGS

### DIFF
--- a/apfsck/Makefile
+++ b/apfsck/Makefile
@@ -15,7 +15,7 @@ override CFLAGS += -Wall -Wno-address-of-packed-member -fno-strict-aliasing -I$(
 
 apfsck: $(OBJS) $(LIBRARY)
 	@echo '  Linking...'
-	@gcc $(CFLAGS) -o apfsck $(OBJS) $(LIBRARY)
+	@gcc $(CFLAGS) $(LDFLAGS) -o apfsck $(OBJS) $(LIBRARY)
 	@echo '  Build complete'
 
 # Build the common libraries

--- a/mkapfs/Makefile
+++ b/mkapfs/Makefile
@@ -14,7 +14,7 @@ override CFLAGS += -Wall -Wno-address-of-packed-member -fno-strict-aliasing -I$(
 
 mkapfs: $(OBJS) $(LIBRARY)
 	@echo '  Linking...'
-	@gcc $(CFLAGS) -o mkapfs $(OBJS) $(LIBRARY)
+	@gcc $(CFLAGS) $(LDFLAGS) -o mkapfs $(OBJS) $(LIBRARY)
 	@echo '  Build complete'
 
 # Build the common libraries


### PR DESCRIPTION
This is a [patch from the AUR](https://aur.archlinux.org/cgit/aur.git/tree/add-ldflags.patch?h=apfsprogs-git&id=c24a2875f89073112532c8196139fd5f7e3daca7) and I thought it would be good to upstream it.
Please double-check, that this patch makes sense.