### PR TITLE
apfsprogs: use relative file path for symlink

### DIFF
--- a/apfsck/Makefile
+++ b/apfsck/Makefile
@@ -39,7 +39,7 @@ clean:
 install:
 	install -d $(BINDIR)
 	install -t $(BINDIR) apfsck
-	ln -fs -T $(BINDIR)/apfsck $(BINDIR)/fsck.apfs
+	ln -fs -T apfsck $(BINDIR)/fsck.apfs
 	install -d $(MANDIR)
 	install -m 644 -t $(MANDIR) apfsck.8
-	ln -fs -T $(MANDIR)/apfsck.8 $(MANDIR)/fsck.apfs.8
+	ln -fs -T apfsck.8 $(MANDIR)/fsck.apfs.8

--- a/mkapfs/Makefile
+++ b/mkapfs/Makefile
@@ -38,7 +38,7 @@ clean:
 install:
 	install -d $(BINDIR)
 	install -t $(BINDIR) mkapfs
-	ln -fs -T $(BINDIR)/mkapfs $(BINDIR)/mkfs.apfs
+	ln -fs -T mkapfs $(BINDIR)/mkfs.apfs
 	install -d $(MANDIR)
 	install -m 644 -t $(MANDIR) mkapfs.8
-	ln -fs -T $(MANDIR)/mkapfs.8 $(MANDIR)/mkfs.apfs.8
+	ln -fs -T mkapfs.8 $(MANDIR)/mkfs.apfs.8


### PR DESCRIPTION
This is slightly more readable, both in the Makefiles and on the filesystem.
Since the executable and the symlink are in the same directory, this should work perfectly fine and I see not downsides.