### PR TITLE
apfsprogs: allow specifying a destination directory when installing

### DIFF
--- a/apfsck/Makefile
+++ b/apfsck/Makefile
@@ -6,8 +6,9 @@ DEPS = $(SRCS:.c=.d)
 LIBDIR = ../lib
 LIBRARY = $(LIBDIR)/libapfs.a
 
-BINDIR = ~/bin
-MANDIR = ~/share/man/man8
+DESTDIR ?= ~
+BINDIR = /bin
+MANDIR = /share/man/man8
 
 SPARSE_VERSION := $(shell sparse --version 2>/dev/null)
 
@@ -37,9 +38,9 @@ endif
 clean:
 	rm -f $(OBJS) $(DEPS) apfsck
 install:
-	install -d $(BINDIR)
-	install -t $(BINDIR) apfsck
-	ln -fs -T apfsck $(BINDIR)/fsck.apfs
-	install -d $(MANDIR)
-	install -m 644 -t $(MANDIR) apfsck.8
-	ln -fs -T apfsck.8 $(MANDIR)/fsck.apfs.8
+	install -d $(DESTDIR)$(BINDIR)
+	install -t $(DESTDIR)$(BINDIR) apfsck
+	ln -fs -T apfsck $(DESTDIR)$(BINDIR)/fsck.apfs
+	install -d $(DESTDIR)$(MANDIR)
+	install -m 644 -t $(DESTDIR)$(MANDIR) apfsck.8
+	ln -fs -T apfsck.8 $(DESTDIR)$(MANDIR)/fsck.apfs.8

--- a/mkapfs/Makefile
+++ b/mkapfs/Makefile
@@ -5,8 +5,9 @@ DEPS = $(SRCS:.c=.d)
 LIBDIR = ../lib
 LIBRARY = $(LIBDIR)/libapfs.a
 
-BINDIR = ~/bin
-MANDIR = ~/share/man/man8
+DESTDIR ?= ~
+BINDIR = /bin
+MANDIR = /share/man/man8
 
 SPARSE_VERSION := $(shell sparse --version 2>/dev/null)
 
@@ -36,9 +37,9 @@ endif
 clean:
 	rm -f $(OBJS) $(DEPS) mkapfs
 install:
-	install -d $(BINDIR)
-	install -t $(BINDIR) mkapfs
-	ln -fs -T mkapfs $(BINDIR)/mkfs.apfs
-	install -d $(MANDIR)
-	install -m 644 -t $(MANDIR) mkapfs.8
-	ln -fs -T mkapfs.8 $(MANDIR)/mkfs.apfs.8
+	install -d $(DESTDIR)$(BINDIR)
+	install -t $(DESTDIR)$(BINDIR) mkapfs
+	ln -fs -T mkapfs $(DESTDIR)$(BINDIR)/mkfs.apfs
+	install -d $(DESTDIR)$(MANDIR)
+	install -m 644 -t $(DESTDIR)$(MANDIR) mkapfs.8
+	ln -fs -T mkapfs.8 $(DESTDIR)$(MANDIR)/mkfs.apfs.8


### PR DESCRIPTION
Changing the destination directory is commonly needed when packaging for distribution. This commit makes it easy to do so without having to change `BINDIR` and `MANDIR`.
This patch is almost identical to https://aur.archlinux.org/cgit/aur.git/tree/destdir.patch?h=apfsprogs-git&id=c3da4488345d720776050f6a562e718d238589fb from the AUR.
It will also make the declaration in Nixpkgs sightly simpler and as a side-effect fix a mistake I accidentally copied from the AUR, copying the man page to the wrong location: https://github.com/NixOS/nixpkgs/blob/40f95ae12ac630b76e8f4aa2d378fd2f2a959ff5/pkgs/tools/filesystems/apfsprogs/default.nix#L26-L27