### PR TITLE
Fix exit code when GIT_COMMIT is not null

### DIFF
--- a/apfs-label/apfs-label.c
+++ b/apfs-label/apfs-label.c
@@ -34,11 +34,13 @@ static void usage(void)
  */
 static void version(void)
 {
-	if (*GIT_COMMIT)
+	if (*GIT_COMMIT) {
 		printf("apfs-label %s\n", GIT_COMMIT);
-	else
+		exit(EXIT_SUCCESS);
+	} else {
 		printf("apfs-label - unknown git commit id\n");
-	exit(EXIT_FAILURE);
+		exit(EXIT_FAILURE);
+	}
 }
 
 /**

--- a/apfs-snap/apfs-snap.c
+++ b/apfs-snap/apfs-snap.c
@@ -29,11 +29,13 @@ static void usage(void)
  */
 static void version(void)
 {
-	if (*GIT_COMMIT)
+	if (*GIT_COMMIT) {
 		printf("apfs-snap %s\n", GIT_COMMIT);
-	else
+		exit(EXIT_SUCCESS);
+	} else {
 		printf("apfs-snap - unknown git commit id\n");
-	exit(EXIT_FAILURE);
+		exit(EXIT_FAILURE);
+	}
 }
 
 /**

--- a/apfsck/apfsck.c
+++ b/apfsck/apfsck.c
@@ -33,11 +33,13 @@ static void usage(void)
  */
 static void version(void)
 {
-	if (*GIT_COMMIT)
+	if (*GIT_COMMIT) {
 		printf("apfsck %s\n", GIT_COMMIT);
-	else
+		exit(EXIT_SUCCESS);
+	} else {
 		printf("apfsck - unknown git commit id\n");
-	exit(EXIT_FAILURE);
+		exit(EXIT_FAILURE);
+	}
 }
 
 /**

--- a/mkapfs/mkapfs.c
+++ b/mkapfs/mkapfs.c
@@ -38,11 +38,13 @@ static void usage(void)
  */
 static void version(void)
 {
-	if (*GIT_COMMIT)
+	if (*GIT_COMMIT) {
 		printf("mkapfs %s\n", GIT_COMMIT);
-	else
+		exit(EXIT_SUCCESS);
+	} else {
 		printf("mkapfs - unknown git commit id\n");
-	exit(EXIT_FAILURE);
+		exit(EXIT_FAILURE);
+	}
 }
 
 /**


### PR DESCRIPTION
- When `GIT_COMMIT` is not null, the return value shouldn't be 1.