### PR TITLE
Use a better method for generating git version

### DIFF
--- a/apfs-label/Makefile
+++ b/apfs-label/Makefile
@@ -11,7 +11,7 @@ MANDIR = /share/man/man8
 
 SPARSE_VERSION := $(shell sparse --version 2>/dev/null)
 
-GIT_COMMIT = $(shell git describe --always HEAD | tail -c 9)
+GIT_COMMIT = "r$(shell git rev-list --count HEAD).$(shell git rev-parse --short=7 HEAD)"
 
 override CFLAGS += -Wall -Wno-address-of-packed-member -fno-strict-aliasing -I$(CURDIR)/../include
 

--- a/apfs-snap/Makefile
+++ b/apfs-snap/Makefile
@@ -8,7 +8,7 @@ MANDIR = /share/man/man8
 
 SPARSE_VERSION := $(shell sparse --version 2>/dev/null)
 
-GIT_COMMIT = $(shell git describe --always HEAD | tail -c 9)
+GIT_COMMIT = "r$(shell git rev-list --count HEAD).$(shell git rev-parse --short=7 HEAD)"
 
 override CFLAGS += -Wall -Wno-address-of-packed-member -fno-strict-aliasing
 

--- a/apfsck/Makefile
+++ b/apfsck/Makefile
@@ -12,7 +12,7 @@ MANDIR = /share/man/man8
 
 SPARSE_VERSION := $(shell sparse --version 2>/dev/null)
 
-GIT_COMMIT = $(shell git describe --always HEAD | tail -c 9)
+GIT_COMMIT = "r$(shell git rev-list --count HEAD).$(shell git rev-parse --short=7 HEAD)"
 
 override CFLAGS += -Wall -Wno-address-of-packed-member -fno-strict-aliasing -I$(CURDIR)/../include
 

--- a/mkapfs/Makefile
+++ b/mkapfs/Makefile
@@ -11,7 +11,7 @@ MANDIR = /share/man/man8
 
 SPARSE_VERSION := $(shell sparse --version 2>/dev/null)
 
-GIT_COMMIT = $(shell git describe --always HEAD | tail -c 9)
+GIT_COMMIT = "r$(shell git rev-list --count HEAD).$(shell git rev-parse --short=7 HEAD)"
 
 override CFLAGS += -Wall -Wno-address-of-packed-member -fno-strict-aliasing -I$(CURDIR)/../include
 


### PR DESCRIPTION
- Use a better method for generating git version according to [ArchWiki](https://wiki.archlinux.org/title/VCS_package_guidelines#Git).