### PR TITLE
chore: adopt better keycmp() implementation

### DIFF
--- a/apfs-label/apfs-label.c
+++ b/apfs-label/apfs-label.c
@@ -222,9 +222,9 @@ static void omap_node_locate_val(struct apfs_btree_node_phys *node, int index, i
 static int omap_keycmp(struct apfs_omap_key *k1, struct apfs_omap_key *k2)
 {
 	if (le64_to_cpu(k1->ok_oid) != le64_to_cpu(k2->ok_oid))
-		return le64_to_cpu(k1->ok_oid) < le64_to_cpu(k2->ok_oid) ? -1 : 1;
+		return le64_to_cpu(k1->ok_oid) - le64_to_cpu(k2->ok_oid);
 	if (le64_to_cpu(k1->ok_xid) != le64_to_cpu(k2->ok_xid))
-		return le64_to_cpu(k1->ok_xid) < le64_to_cpu(k2->ok_xid) ? -1 : 1;
+		return le64_to_cpu(k1->ok_xid) - le64_to_cpu(k2->ok_xid);
 	return 0;
 }
 

--- a/apfsck/key.c
+++ b/apfsck/key.c
@@ -72,11 +72,11 @@ void read_free_queue_key(void *raw, int size, struct key *key)
 int keycmp(struct key *k1, struct key *k2)
 {
 	if (k1->id != k2->id)
-		return k1->id < k2->id ? -1 : 1;
+		return k1->id - k2->id;
 	if (k1->type != k2->type)
-		return k1->type < k2->type ? -1 : 1;
+		return k1->type - k2->type;
 	if (k1->number != k2->number)
-		return k1->number < k2->number ? -1 : 1;
+		return k1->number - k2->number;
 	if (!k1->name) /* Keys of this type have no name */
 		return 0;
 


### PR DESCRIPTION
According to [the source code of `strcmp()` in glibc](https://github.com/bminor/glibc/blob/master/string/strcmp.c#L110), the return value is the difference of first different character in two strings.

For `keycmp()`, we can adopt an implementation akin to `strcmp()` in glibc.